### PR TITLE
build: Add a basic nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ envious-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Nix
+.nix-mix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710503106,
+        "narHash": "sha256-WQenjcuNH9cnEYqh/PFxpmjK9PQnEPGt1Z7TCfYBhXs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b1d47989352fcb722a1f19295a9461ed1ef8435a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs@{ nixpkgs, utils, ... }:
+    let
+      supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux"];
+    in
+      utils.lib.eachSystem supportedSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+
+          elixir = pkgs.beam.packages.erlang_25.elixir_1_16;
+        in {
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs;
+              [elixir mix2nix] ++
+              lib.optionals stdenv.isLinux [ inotify-tools ] ++
+              lib.optionals stdenv.isDarwin
+                (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices ]);
+
+            shellHook = ''
+              # this allows mix to work on the local directory
+              mkdir -p .nix-mix .nix-hex
+              export MIX_HOME=$PWD/.nix-mix
+              export HEX_HOME=$PWD/.nix-mix
+
+              # make hex from Nixpkgs available
+              # `mix local.hex` will install hex into MIX_HOME and should take precedence
+              export MIX_PATH="${pkgs.beam.packages.erlang.hex}/lib/erlang/lib/hex/ebin"
+              export PATH=$MIX_HOME/bin:$HEX_HOME/bin:$PATH
+              export LANG=C.UTF-8
+              # keep your shell history in iex
+              export ERL_AFLAGS="-kernel shell_history enabled"
+            '';
+          };
+        });
+}

--- a/mix_deps.nix
+++ b/mix_deps.nix
@@ -1,0 +1,90 @@
+{ lib, beamPackages, overrides ? (x: y: {}) }:
+
+let
+  buildRebar3 = lib.makeOverridable beamPackages.buildRebar3;
+  buildMix = lib.makeOverridable beamPackages.buildMix;
+  buildErlangMk = lib.makeOverridable beamPackages.buildErlangMk;
+
+  self = packages // (overrides self packages);
+
+  packages = with beamPackages; with self; {
+    earmark_parser = buildMix rec {
+      name = "earmark_parser";
+      version = "1.4.39";
+
+      src = fetchHex {
+        pkg = "earmark_parser";
+        version = "${version}";
+        sha256 = "06553a88d1f1846da9ef066b87b57c6f605552cfbe40d20bd8d59cc6bde41944";
+      };
+
+      beamDeps = [];
+    };
+
+    ex_doc = buildMix rec {
+      name = "ex_doc";
+      version = "0.31.2";
+
+      src = fetchHex {
+        pkg = "ex_doc";
+        version = "${version}";
+        sha256 = "317346c14febaba9ca40fd97b5b5919f7751fb85d399cc8e7e8872049f37e0af";
+      };
+
+      beamDeps = [ earmark_parser makeup_elixir makeup_erlang ];
+    };
+
+    makeup = buildMix rec {
+      name = "makeup";
+      version = "1.1.1";
+
+      src = fetchHex {
+        pkg = "makeup";
+        version = "${version}";
+        sha256 = "5dc62fbdd0de44de194898b6710692490be74baa02d9d108bc29f007783b0b48";
+      };
+
+      beamDeps = [ nimble_parsec ];
+    };
+
+    makeup_elixir = buildMix rec {
+      name = "makeup_elixir";
+      version = "0.16.2";
+
+      src = fetchHex {
+        pkg = "makeup_elixir";
+        version = "${version}";
+        sha256 = "41193978704763f6bbe6cc2758b84909e62984c7752b3784bd3c218bb341706b";
+      };
+
+      beamDeps = [ makeup nimble_parsec ];
+    };
+
+    makeup_erlang = buildMix rec {
+      name = "makeup_erlang";
+      version = "0.1.5";
+
+      src = fetchHex {
+        pkg = "makeup_erlang";
+        version = "${version}";
+        sha256 = "94d2e986428585a21516d7d7149781480013c56e30c6a233534bedf38867a59a";
+      };
+
+      beamDeps = [ makeup ];
+    };
+
+    nimble_parsec = buildMix rec {
+      name = "nimble_parsec";
+      version = "1.4.0";
+
+      src = fetchHex {
+        pkg = "nimble_parsec";
+        version = "${version}";
+        sha256 = "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28";
+      };
+
+      beamDeps = [];
+    };
+  };
+in self
+


### PR DESCRIPTION
Not sure if this is useful or not for you folks, but I created a basic flake with a shell:

```
┌─[sgillespie@sean-work]──(~/dev/elixir/envious)
└─[✗:14:34]── ➤ nix develop .
┌─(sgillespie@sean-work)──(~/dev/elixir/envious)
└─(✓:14:35:04)── -> mix test
....
Finished in 0.03 seconds (0.03s async, 0.00s sync)
4 tests, 0 failures

Randomized with seed 738075
```