### PR TITLE
Allow underscore in env name

### DIFF
--- a/lib/envious/parser.ex
+++ b/lib/envious/parser.ex
@@ -35,7 +35,7 @@ defmodule Envious.Parser do
 
   var_name =
     empty()
-    |> concat(utf8_string([?A..?Z], min: 1))
+    |> concat(utf8_string([?A..?Z, ?_], min: 1))
 
   val =
     empty()

--- a/test/envious/parser_test.exs
+++ b/test/envious/parser_test.exs
@@ -11,4 +11,9 @@ defmodule Envious.ParserTest do
     assert Parser.parse("FOO=bar\nBAZ=qux") ==
              {:ok, ["FOO", "bar", "BAZ", "qux"], "", %{}, {2, 8}, 15}
   end
+
+  test "underscore" do
+    assert Parser.parse("FOO_BAR=bar\nBAZ_QUX=qux") ==
+             {:ok, ["FOO_BAR", "bar", "BAZ_QUX", "qux"], "", %{}, {2, 12}, 23}
+  end
 end


### PR DESCRIPTION
parse `FOO_BAR=baz` to `{:ok, %{"FOO_BAR" => "baz"}}`